### PR TITLE
Fix CSV parser validation bug

### DIFF
--- a/src/main/java/com/eptexcoatings/assignment/service/impl/CsvFileParserImpl.java
+++ b/src/main/java/com/eptexcoatings/assignment/service/impl/CsvFileParserImpl.java
@@ -48,11 +48,15 @@ public class CsvFileParserImpl implements CsvFileParser {
 
     @Override
     public List<CsvRecord> convertToCsvRecords(List<String[]> records) throws RecordNotFoundException {
-        if (CollectionUtils.isEmpty(records) && records.size() > 1) {
+        if (CollectionUtils.isEmpty(records) || records.size() <= 1) {
             throw new RecordNotFoundException("No record");
         }
+
+        // remove header row before converting
         records.remove(0);
-        return records.stream().map(csvDtoAssembler::makeCsvRecord)
+
+        return records.stream()
+                .map(csvDtoAssembler::makeCsvRecord)
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Summary
- fix validation condition in `CsvFileParserImpl.convertToCsvRecords`

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482cdfc85c8326a1b778540edcec8c